### PR TITLE
exclude foreign tables

### DIFF
--- a/schemainspect/pg/sql/deps.sql
+++ b/schemainspect/pg/sql/deps.sql
@@ -15,6 +15,9 @@ with things1 as (
     null as identity_arguments,
     relkind as kind
   from pg_class
+  where oid not in (
+    select ftrelid from pg_foreign_table
+  )
 ),
 extension_objids as (
   select


### PR DESCRIPTION
When using migra with postgres databases with foreign tables a key error is raised:

Traceback (most recent call last):
  File "/usr/local/bin/migra", line 10, in <module>
    sys.exit(do_command())
  File "/Library/Python/2.7/site-packages/migra/command.py", line 101, in do_command
    status = run(args)
  File "/Library/Python/2.7/site-packages/migra/command.py", line 72, in run
    m = Migration(ac0, ac1, schema=schema)
  File "/Library/Python/2.7/site-packages/migra/migra.py", line 22, in __init__
    self.changes.i_from = get_inspector(x_from, schema=schema)
  File "/Library/Python/2.7/site-packages/schemainspect/get.py", line 18, in get_inspector
    inspected = ic(c)
  File "/Library/Python/2.7/site-packages/schemainspect/pg/obj.py", line 659, in __init__
    super(PostgreSQL, self).__init__(c, include_internal)
  File "/Library/Python/2.7/site-packages/schemainspect/inspector.py", line 25, in __init__
    self.load_all()
  File "/Library/Python/2.7/site-packages/schemainspect/pg/obj.py", line 668, in load_all
    self.load_deps()
  File "/Library/Python/2.7/site-packages/schemainspect/pg/obj.py", line 738, in load_deps
    self.selectables[x_dependent_on].dependents.append(x)
KeyError: '"no"."matter"'


This PR excludes foreign tables all together by excluding anything in [pg_foreign_table](https://www.postgresql.org/docs/9.3/catalog-pg-foreign-table.html)

side note:  I'm new to migra and this error is preventing me from experimenting with the library.  FDW seem like they'd be difficult to support and I'm happy to find another way to deal with that if migra solves other problems for me. 
